### PR TITLE
Adds color to git prompt when files are changed

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-source .dotfiles/files/bashrc
+source ~/.dotfiles/files/bashrc

--- a/files/bashrc._git
+++ b/files/bashrc._git
@@ -9,10 +9,6 @@ source_if ~/.git-completion.bash
 # Github PAT
 # Moved to .vars
 
-function git_branch() {
-  git rev-parse --abbrev-ref HEAD 2> /dev/null
-}
-
 alias gs='git status'
 alias GS='git status'
 alias gd='git diff'
@@ -26,15 +22,25 @@ alias gco='git checkout'
 alias gstash='git stash'
 alias gp='git pull'
 alias gpom='git pull origin master'
-alias gpo="git push origin $(git_branch)"
 alias gmm='git merge master'
 
 # Makes my git prompt beautiful
+function git_branch() {
+  git rev-parse --abbrev-ref HEAD 2> /dev/null
+}
+alias gpo="git push origin $(git_branch)"
 function git_branch_paran() {
   git rev-parse 2> /dev/null 1>&2 && echo "(`git_branch`)"
 }
 function prompt(){
-  PS1="\[\033[01;34m\]\u\[\033[01;37m\]@\h\[\033[01;32m\] \W $(git_branch_paran)\[\033[00m\] > "
+  git rev-parse 2> /dev/null 1>&2 && git diff-index --quiet HEAD --
+  changed=$?
+  color_code='32'
+  if [ $changed -eq 1 ]
+  then
+    color_code='31'
+  fi
+  PS1="\[\033[01;34m\]\u\[\033[01;37m\]@\h\[\033[01;${color_code}m\] \W $(git_branch_paran)\[\033[00m\] > "
 }
 export PROMPT_COMMAND=prompt
 


### PR DESCRIPTION
Prompt includes dir name and branch name in red when directory is a git project and files are changed. Otherwise in green.

Preview:
<img width="670" alt="screen shot 2017-05-05 at 8 55 31 pm" src="https://cloud.githubusercontent.com/assets/17204163/25752212/378cd0c6-31d5-11e7-8da3-9945f9552ff9.png">
